### PR TITLE
MPI Support for Motion Correction From Star File

### DIFF
--- a/src/apps/motion_correction_mpi.cpp
+++ b/src/apps/motion_correction_mpi.cpp
@@ -17,12 +17,11 @@
  * source code. Additional authorship citations may be added, but existing
  * author citations must be preserved.
  ***************************************************************************/
-#include <src/motioncorr_own_devolved.h>
+#include <src/motioncorr_own_devolved_mpi.h>
 
-
-int main(int argc, char *argv[])
+ int main(int argc, char *argv[])
 {
-	MotioncorrOwnDevolved prm;
+	MotioncorrOwnDevolvedMpi prm;
 
 	try
 	{
@@ -33,8 +32,9 @@ int main(int argc, char *argv[])
 	catch (RelionError XE)
 	{
 		std::cerr << XE;
-		return RELION_EXIT_FAILURE;
+		MPI_Abort(MPI_COMM_WORLD, RELION_EXIT_FAILURE);
 	}
 
+	MPI_Barrier(MPI_COMM_WORLD);
 	return RELION_EXIT_SUCCESS;
 }

--- a/src/motioncorr_own_devolved.cpp
+++ b/src/motioncorr_own_devolved.cpp
@@ -46,7 +46,7 @@ void MotioncorrOwnDevolved::run()
 	}
 	bool result;
 	result = executeOwnMotionCorrection(mic, fromStarFile);
-	if (result && !fromStarFile) saveModel(mic);
+	if (result) saveModel(mic);
 }
 
 FileName MotioncorrOwnDevolved::getOutputFileNames(FileName fn_mic, bool continue_even_odd)

--- a/src/motioncorr_own_devolved_mpi.cpp
+++ b/src/motioncorr_own_devolved_mpi.cpp
@@ -1,0 +1,94 @@
+/***************************************************************************
+ *
+ * Author: "Sjors H.W. Scheres"
+ * MRC Laboratory of Molecular Biology
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * This complete copyright notice must be included in any revised version of the
+ * source code. Additional authorship citations may be added, but existing
+ * author citations must be preserved.
+ ***************************************************************************/
+#include "src/motioncorr_own_devolved_mpi.h"
+
+void MotioncorrOwnDevolvedMpi::addClArgs()
+{
+	int path_section =  parser.addSection("In/out paths options");
+	motion_correction_star_path = parser.getOption("--mc_star", "Path to star file containing motion correction model information from a previous run", "");
+	MotioncorrRunner::addClArgs();
+}
+
+void MotioncorrOwnDevolvedMpi::run()
+{
+    prepareGainReference(node->isLeader());
+
+    bool fromStarFile = false;
+
+    if (motion_correction_star_path != "") 
+    {
+        MetaDataTable MDin;
+        MDin.read(motion_correction_star_path, "micrographs");
+        
+        FOR_ALL_OBJECTS_IN_METADATA_TABLE(MDin)
+        {
+            FileName fn_stars;
+            MDin.getValue(EMDL_MICROGRAPH_METADATA_NAME, fn_stars);
+
+            fn_stars_all.push_back(fn_stars);
+        }
+    }
+    
+    
+	MPI_Barrier(MPI_COMM_WORLD); // wait for the leader to write the gain reference
+
+	// Each node does part of the work
+	long int my_first_micrograph, my_last_micrograph, my_nr_micrographs;
+	divide_equally(fn_micrographs.size(), node->size, node->rank, my_first_micrograph, my_last_micrograph);
+	my_nr_micrographs = my_last_micrograph - my_first_micrograph + 1;
+
+    for (long int imic = my_first_micrograph; imic <= my_last_micrograph; imic++)
+	{
+        // Abort through the pipeline_control system
+		if (pipeline_control_check_abort_job())
+			MPI_Abort(MPI_COMM_WORLD, RELION_EXIT_ABORTED);
+
+        Micrograph mic(fn_micrographs[imic], fn_gain_reference, bin_factor, eer_upsampling, eer_grouping);
+        if (motion_correction_star_path != "") 
+        {
+            FileName shifts_star_path = fn_stars_all[imic];
+    		Micrograph mic2(shifts_star_path, "", 1);
+
+            mic = mic2;
+	    	fromStarFile = true;
+	    }
+        
+        if (pre_exposure_micrographs.size() == imic)
+    		mic.pre_exposure = pre_exposure + pre_exposure_micrographs[imic];
+		else
+    		mic.pre_exposure = pre_exposure;
+
+        // Get angpix and voltage from the optics groups:
+		obsModel.opticsMdt.getValue(EMDL_CTF_VOLTAGE, voltage, optics_group_micrographs[imic]-1);
+		obsModel.opticsMdt.getValue(EMDL_MICROGRAPH_ORIGINAL_PIXEL_SIZE, angpix, optics_group_micrographs[imic]-1);
+
+        bool result;
+        result = executeOwnMotionCorrection(mic, fromStarFile);
+
+        if (result && !fromStarFile)
+			saveModel(mic);
+	}
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Only the leader writes the joined result file
+    if (node->isLeader() && !fromStarFile)
+        generateLogFilePDFAndWriteStarFiles();
+}

--- a/src/motioncorr_own_devolved_mpi.cpp
+++ b/src/motioncorr_own_devolved_mpi.cpp
@@ -82,7 +82,7 @@ void MotioncorrOwnDevolvedMpi::run()
         bool result;
         result = executeOwnMotionCorrection(mic, fromStarFile);
 
-        if (result && !fromStarFile)
+        if (result)
 			saveModel(mic);
 	}
 

--- a/src/motioncorr_own_devolved_mpi.cpp
+++ b/src/motioncorr_own_devolved_mpi.cpp
@@ -89,6 +89,6 @@ void MotioncorrOwnDevolvedMpi::run()
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Only the leader writes the joined result file
-    if (node->isLeader() && !fromStarFile)
+    if (node->isLeader())
         generateLogFilePDFAndWriteStarFiles();
 }

--- a/src/motioncorr_own_devolved_mpi.h
+++ b/src/motioncorr_own_devolved_mpi.h
@@ -17,24 +17,31 @@
  * source code. Additional authorship citations may be added, but existing
  * author citations must be preserved.
  ***************************************************************************/
-#include <src/motioncorr_own_devolved.h>
 
+#ifndef MOTIONCORR_OWN_DEVOLVED_MPI_H_
+#define MOTIONCORR_OWN_DEVOLVED_MPI_H_
 
-int main(int argc, char *argv[])
+#include "src/motioncorr_runner_mpi.h"
+
+class MotioncorrOwnDevolvedMpi: public MotioncorrRunnerMpi
 {
-	MotioncorrOwnDevolved prm;
 
-	try
-	{
-		prm.read(argc, argv);
-		prm.initialise();
-		prm.run();
-	}
-	catch (RelionError XE)
-	{
-		std::cerr << XE;
-		return RELION_EXIT_FAILURE;
-	}
+public:
+    /** Read
+     * This could take care of mpi-parallelisation-dependent variables
+     */
 
-	return RELION_EXIT_SUCCESS;
-}
+    void addClArgs() override;
+
+    // Parallelized run function
+    void run();
+
+    FileName movie_path;
+    FileName micrograph_path;
+    FileName motion_correction_star_path;
+
+    // Filenames of the .STAR files containing pre-calculated shifts
+    std::vector<FileName> fn_stars_all;
+};
+
+#endif /* MOTIONCORR_RUNNER_MPI_H_ */

--- a/src/motioncorr_own_devolved_mpi.h
+++ b/src/motioncorr_own_devolved_mpi.h
@@ -27,9 +27,6 @@ class MotioncorrOwnDevolvedMpi: public MotioncorrRunnerMpi
 {
 
 public:
-    /** Read
-     * This could take care of mpi-parallelisation-dependent variables
-     */
 
     void addClArgs() override;
 

--- a/src/motioncorr_runner.cpp
+++ b/src/motioncorr_runner.cpp
@@ -296,6 +296,7 @@ void MotioncorrRunner::initialise()
 		optics_group_micrographs.resize(fn_in.size(), 1);
 		obsModel.opticsMdt.clear();
 		obsModel.opticsMdt.addObject();
+		pre_exposure_micrographs.assign(fn_micrographs.size(), 0.0);
 	}
 
 	// Make sure obsModel.opticsMdt has all the necessary information

--- a/src/motioncorr_runner_mpi.cpp
+++ b/src/motioncorr_runner_mpi.cpp
@@ -68,7 +68,11 @@ void MotioncorrRunnerMpi::run()
 			MPI_Abort(MPI_COMM_WORLD, RELION_EXIT_ABORTED);
 
 		Micrograph mic(fn_micrographs[imic], fn_gain_reference, bin_factor, eer_upsampling, eer_grouping);
-        mic.pre_exposure = pre_exposure + pre_exposure_micrographs[imic];
+        
+		if (pre_exposure_micrographs.size() == imic)
+			mic.pre_exposure = pre_exposure + pre_exposure_micrographs[imic];
+		else
+    		mic.pre_exposure = pre_exposure;
 
         // Get angpix and voltage from the optics groups:
 		obsModel.opticsMdt.getValue(EMDL_CTF_VOLTAGE, voltage, optics_group_micrographs[imic]-1);

--- a/src/motioncorr_runner_mpi.h
+++ b/src/motioncorr_runner_mpi.h
@@ -27,7 +27,7 @@
 
 class MotioncorrRunnerMpi: public MotioncorrRunner
 {
-private:
+protected:
 	MpiNode *node;
 
 public:


### PR DESCRIPTION
MPI Support for relion_motion_correction & option to run job with pre-calculated shifts.

Run with:

```
mpirun -n 4  relion_motion_correction_mpi --use_own --i Import/job001/movies.star --gainref Movies/gain.mrc
```
```
mpirun -n 4 relion_motion_correction_mpi --use_own --i Import/job001/movies.star --mc_star MotionCorr/corrected_micrographs.star --gainref Movies/gain.mrc
``` 

The first command should generate the file ```MotionCorr/corrected_micrographs.star```.