### PR TITLE
Mc devolve from star mpi

### DIFF
--- a/src/motioncorr_own_devolved.cpp
+++ b/src/motioncorr_own_devolved.cpp
@@ -28,7 +28,7 @@ void MotioncorrOwnDevolved::addClArgs()
 {
 	int path_section =  parser.addSection("In/out paths options");
 	movie_path = parser.getOption("--in_movie", "Path to input movie");
-	// micrograph_path = parser.getOption("--out_mic", "Output micrograph path");
+	micrograph_path = parser.getOption("--out_mic", "Output micrograph path","");
 	motion_correction_star_path = parser.getOption("--mc_star", "Path to star file containing motion correction model information from a previous run", "");
 	MotioncorrRunner::addClArgs();
 }
@@ -51,24 +51,29 @@ void MotioncorrOwnDevolved::run()
 
 FileName MotioncorrOwnDevolved::getOutputFileNames(FileName fn_mic, bool continue_even_odd)
 {
-	// If there are any dots in the filename, replace them by underscores
-	FileName fn_root = fn_mic.getBaseName();
-	fn_root = fn_root.withoutExtension();
+	if (micrograph_path != "") {
+		return micrograph_path;
+	} else 
+	{
+		// If there are any dots in the filename, replace them by underscores
+		FileName fn_root = fn_mic.getBaseName();
+		fn_root = fn_root.withoutExtension();
 
-	size_t pos = 0;
-	while (true)
-	{
-		pos = fn_root.find(".");
-		if (pos == std::string::npos)
-			break;
-		fn_root.replace(pos, 1, "_");
-	}
-	if (continue_even_odd)
-	{
-		return fn_out + fn_root + "_EVN.mrc";
-	}
-	else
-	{
-	return fn_out + fn_root + ".mrc";
+		size_t pos = 0;
+		while (true)
+		{
+			pos = fn_root.find(".");
+			if (pos == std::string::npos)
+				break;
+			fn_root.replace(pos, 1, "_");
+		}
+		if (continue_even_odd)
+		{
+			return fn_out + fn_root + "_EVN.mrc";
+		}
+		else
+		{
+		return fn_out + fn_root + ".mrc";
+		}
 	}
 }

--- a/src/motioncorr_own_devolved.cpp
+++ b/src/motioncorr_own_devolved.cpp
@@ -28,7 +28,7 @@ void MotioncorrOwnDevolved::addClArgs()
 {
 	int path_section =  parser.addSection("In/out paths options");
 	movie_path = parser.getOption("--in_movie", "Path to input movie");
-	micrograph_path = parser.getOption("--out_mic", "Output micrograph path");
+	// micrograph_path = parser.getOption("--out_mic", "Output micrograph path");
 	motion_correction_star_path = parser.getOption("--mc_star", "Path to star file containing motion correction model information from a previous run", "");
 	MotioncorrRunner::addClArgs();
 }
@@ -49,7 +49,7 @@ void MotioncorrOwnDevolved::run()
 	if (result) saveModel(mic);
 }
 
-FileName MotioncorrOwnDevolved::getOutputFileNames(FileName fn_mic, bool continue_even_odd)
-{
-	return micrograph_path;
-}
+// FileName MotioncorrOwnDevolved::getOutputFileNames(FileName fn_mic, bool continue_even_odd)
+// {
+// 	return fn_out;
+// }

--- a/src/motioncorr_own_devolved.cpp
+++ b/src/motioncorr_own_devolved.cpp
@@ -49,7 +49,26 @@ void MotioncorrOwnDevolved::run()
 	if (result) saveModel(mic);
 }
 
-// FileName MotioncorrOwnDevolved::getOutputFileNames(FileName fn_mic, bool continue_even_odd)
-// {
-// 	return fn_out;
-// }
+FileName MotioncorrOwnDevolved::getOutputFileNames(FileName fn_mic, bool continue_even_odd)
+{
+	// If there are any dots in the filename, replace them by underscores
+	FileName fn_root = fn_mic.getBaseName();
+	fn_root = fn_root.withoutExtension();
+
+	size_t pos = 0;
+	while (true)
+	{
+		pos = fn_root.find(".");
+		if (pos == std::string::npos)
+			break;
+		fn_root.replace(pos, 1, "_");
+	}
+	if (continue_even_odd)
+	{
+		return fn_out + fn_root + "_EVN.mrc";
+	}
+	else
+	{
+	return fn_out + fn_root + ".mrc";
+	}
+}

--- a/src/motioncorr_own_devolved.h
+++ b/src/motioncorr_own_devolved.h
@@ -38,7 +38,7 @@ public:
     // Parallelized run function
     void run();
 
-    FileName getOutputFileNames(FileName fn_mic, bool continue_even_odd = false) override;
+    // FileName getOutputFileNames(FileName fn_mic, bool continue_even_odd = false) override;
 
     FileName movie_path;
     FileName micrograph_path;

--- a/src/motioncorr_own_devolved.h
+++ b/src/motioncorr_own_devolved.h
@@ -38,7 +38,7 @@ public:
     // Parallelized run function
     void run();
 
-    // FileName getOutputFileNames(FileName fn_mic, bool continue_even_odd = false) override;
+    FileName getOutputFileNames(FileName fn_mic, bool continue_even_odd = false) override;
 
     FileName movie_path;
     FileName micrograph_path;


### PR DESCRIPTION
Modified the `getOutputFileNames` method (overriden in `MotioncorrOwnDevolved`) to write output files to job directory/the directory specified by `--o` argument.